### PR TITLE
Add net promoter score calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Net Promoter Calculator
+
+This repository provides a simple Python utility to calculate a Net Promoter Score (NPS).
+
+## Usage
+
+```
+python3 nps.py 9 10 7 8 6
+```
+
+Alternatively, you can supply a file containing one score per line:
+
+```
+python3 nps.py --file scores.txt
+```
+
+## Running Tests
+
+```
+python3 -m unittest
+```

--- a/nps.py
+++ b/nps.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Net Promoter Score calculator."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Iterable, Sequence
+
+
+def calculate_nps(scores: Sequence[int]) -> float:
+    """Calculate the Net Promoter Score from survey responses.
+
+    Args:
+        scores: Iterable of integer scores from 0 to 10.
+
+    Returns:
+        Net Promoter Score as a float between -100 and 100.
+
+    Raises:
+        ValueError: If the score list is empty or contains invalid values.
+    """
+    if not scores:
+        raise ValueError("Scores list cannot be empty")
+
+    promoters = detractors = 0
+    for score in scores:
+        if not 0 <= score <= 10:
+            raise ValueError("Scores must be between 0 and 10")
+        if score >= 9:
+            promoters += 1
+        elif score <= 6:
+            detractors += 1
+
+    nps = (promoters - detractors) / len(scores) * 100
+    return float(nps)
+
+
+def _parse_args(args: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Calculate Net Promoter Score")
+    parser.add_argument(
+        "scores",
+        nargs="*",
+        type=int,
+        help="List of scores (0-10)",
+    )
+    parser.add_argument(
+        "-f",
+        "--file",
+        type=str,
+        help="File containing one score per line",
+    )
+    return parser.parse_args(args)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = _parse_args(argv)
+
+    scores: list[int] = []
+    if args.file:
+        with open(args.file) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    scores.append(int(line))
+    scores.extend(args.scores)
+
+    nps = calculate_nps(scores)
+    print(f"NPS: {nps:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_nps.py
+++ b/test_nps.py
@@ -1,0 +1,28 @@
+import unittest
+from nps import calculate_nps
+
+
+class TestCalculateNPS(unittest.TestCase):
+    def test_basic(self):
+        scores = [0, 5, 7, 8, 9, 10]
+        self.assertEqual(calculate_nps(scores), 0.0)
+
+    def test_all_promoters(self):
+        scores = [9, 10, 10, 9]
+        self.assertEqual(calculate_nps(scores), 100.0)
+
+    def test_all_detractors(self):
+        scores = [0, 1, 2, 3, 4, 5, 6]
+        self.assertEqual(calculate_nps(scores), -100.0)
+
+    def test_empty(self):
+        with self.assertRaises(ValueError):
+            calculate_nps([])
+
+    def test_invalid_values(self):
+        with self.assertRaises(ValueError):
+            calculate_nps([11, -1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `calculate_nps` function and CLI in `nps.py`
- add tests for NPS logic
- document usage and how to run tests

## Testing
- `python3 -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_68790a9e527883319d9725330ad5cc47