### PR TITLE
Add NPS calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Net Promoter Score Calculator
+
+This repository contains a simple command line tool for calculating the
+Net Promoter Score (NPS).
+
+## Usage
+
+```
+python nps.py 10 9 8 7 6
+```
+
+The command accepts scores between 0 and 10. The resulting NPS is printed
+as a percentage. The NPS is computed as:
+
+```
+((number_of_promoters - number_of_detractors) / total_responses) * 100
+```
+
+Promoters are scores of 9 or 10. Detractors are scores of 6 or lower.
+All other scores are considered passives and do not affect the score.

--- a/nps.py
+++ b/nps.py
@@ -1,0 +1,36 @@
+# nps.py
+"""Net Promoter Score calculator CLI"""
+
+from __future__ import annotations
+import argparse
+
+
+def calculate_nps(scores: list[int]) -> float:
+    """Calculate the Net Promoter Score from a list of ratings (0-10)."""
+    if not scores:
+        raise ValueError("Score list cannot be empty")
+    for score in scores:
+        if score < 0 or score > 10:
+            raise ValueError("Scores must be between 0 and 10 inclusive")
+
+    promoters = sum(1 for s in scores if s >= 9)
+    detractors = sum(1 for s in scores if s <= 6)
+    nps = (promoters - detractors) / len(scores) * 100
+    return nps
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "scores",
+        nargs="+",
+        type=int,
+        help="List of integer scores 0-10",
+    )
+    args = parser.parse_args(argv)
+    nps = calculate_nps(args.scores)
+    print(f"Net Promoter Score: {nps:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_nps.py
+++ b/tests/test_nps.py
@@ -1,0 +1,19 @@
+import pytest
+from nps import calculate_nps
+
+
+def test_calculate_nps_basic():
+    scores = [10, 9, 9, 7, 5, 6]
+    # promoters=3, detractors=2 => (3-2)/6*100=16.666...
+    result = calculate_nps(scores)
+    assert round(result, 2) == 16.67
+
+
+def test_calculate_nps_invalid_range():
+    with pytest.raises(ValueError):
+        calculate_nps([11])
+
+
+def test_calculate_nps_empty():
+    with pytest.raises(ValueError):
+        calculate_nps([])


### PR DESCRIPTION
## Summary
- implement `calculate_nps` and CLI interface in `nps.py`
- add tests covering success and error cases
- document usage in README

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68790a9e527883319d9725330ad5cc47